### PR TITLE
Fixes to sql CREATE TABLE parsing and DB export

### DIFF
--- a/src/fqlite/export/SQLiteDatabaseCreator.java
+++ b/src/fqlite/export/SQLiteDatabaseCreator.java
@@ -121,7 +121,7 @@ public class SQLiteDatabaseCreator {
 
             // iterate over all Descriptor objects, extract the original SQL command and execute it
             for(TableDescriptor desc : tables) {
-                if (desc.sql.isEmpty() || desc.tblname.startsWith("sqlite_"))
+                if (desc.sql.isEmpty() || desc.tblname.startsWith("sqlite_") || desc.isVirtual())
                     continue;
 
                 String stm = createTableSql(desc.tblname,desc.columnnames,desc.sqltypes, isWAL);

--- a/src/fqlite/parser/SimpleSQLiteParser.java
+++ b/src/fqlite/parser/SimpleSQLiteParser.java
@@ -371,8 +371,6 @@ public class SimpleSQLiteParser {
         	
         	@Override public void enterColumn_name(SQLiteParser.Column_nameContext ctx) 
         	{
-        		sqltypes_defined = false;
-        		
         		if(inForeignTable)
         		{
         			inForeignTable = false;
@@ -383,9 +381,18 @@ public class SimpleSQLiteParser {
         		{
         			return;
         		}
-        		cons="";
-        		
         		String colname = ctx.getText();
+        		
+    			// Sanity check for duplicate column name
+    			// TODO: This happens unfortunately in yet unhandled construct "CHECK(...)"
+    			if(colnames.contains(colname))
+    			{
+    				return;
+    			}
+    			
+    			sqltypes_defined = false;
+        		
+        		cons="";
         		
         		//System.out.println("enterColumn_name()::colname =" + colname);
         		
@@ -423,7 +430,8 @@ public class SimpleSQLiteParser {
         	    value = value.trim();
 
 				// case: there is actually no type info given, but a NOT NULL constraint
-				if(value.equals("NOT"))
+        	    // or DEFAULT XXX
+				if(value.equals("NOT") || value.equals("DEFAULT"))
 					value = "BLOB";
         	    if(value.isEmpty())
         	    	value = "BLOB";


### PR DESCRIPTION
- Some simple fix to duplicate column names in e.g. :
```
"some_column" TEXT DEFAULT NULL CHECK("some_column" LIKE 'FOO:') UNIQUE
```
This fixes it for now, but the parser should be made aware when inside `CHECK()` 

- Fix a `DEFAULT NULL` column without explicit type.

- Export to DB to exclude *virtual* table (fts3-5) for now  #20 
