### PR TITLE
Build Fedora/RHEL RPM package in release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,6 +261,18 @@ jobs:
           find build/jpackage -name "*.deb" -exec sh -c 'x="{}"; mv "$x" "${{ env.OUTPUT_FILE_NAME }}"' \;
           echo "OUTPUT_FILE=$(realpath ${{ env.OUTPUT_FILE_NAME }})" >> $GITHUB_ENV
 
+      - name: Create Linux RPM installer (Fedora/RHEL)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm
+          rm -rf build/jpackage
+          ./gradlew --info --stacktrace jpackage -PinstallerType=rpm --rerun-tasks
+          RPM_FILE_NAME="fqlite-${{ needs.get-version.outputs.version }}-$(uname -m).rpm"
+          mv "$(find build/jpackage -name '*.rpm' | head -n1)" "$RPM_FILE_NAME"
+          echo "RPM_OUTPUT_FILE_NAME=$RPM_FILE_NAME" >> $GITHUB_ENV
+          echo "RPM_OUTPUT_FILE=$(realpath $RPM_FILE_NAME)" >> $GITHUB_ENV
+
       - name: Create Windows installer
         if: startsWith(matrix.os, 'windows')
         run: |
@@ -294,6 +306,21 @@ jobs:
         with:
           name: "${{ env.OUTPUT_FILE_NAME }}"
           path: "${{ env.OUTPUT_FILE }}"
+          overwrite: true
+          retention-days: 14
+
+      - name: Generate RPM artifact attestation
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "${{ env.RPM_OUTPUT_FILE }}"
+
+      - name: Upload RPM artifact
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ env.RPM_OUTPUT_FILE_NAME }}"
+          path: "${{ env.RPM_OUTPUT_FILE }}"
           overwrite: true
           retention-days: 14
 

--- a/.github/workflows/build_secure.yml
+++ b/.github/workflows/build_secure.yml
@@ -261,6 +261,18 @@ jobs:
           find build/jpackage -name "*.deb" -exec sh -c 'x="{}"; mv "$x" "${{ env.OUTPUT_FILE_NAME }}"' \;
           echo "OUTPUT_FILE=$(realpath ${{ env.OUTPUT_FILE_NAME }})" >> $GITHUB_ENV
 
+      - name: Create Linux RPM installer (Fedora/RHEL)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm
+          rm -rf build/jpackage
+          ./gradlew --info --stacktrace jpackage -PinstallerType=rpm --rerun-tasks
+          RPM_FILE_NAME="fqlite-${{ needs.get-version.outputs.version }}-$(uname -m).rpm"
+          mv "$(find build/jpackage -name '*.rpm' | head -n1)" "$RPM_FILE_NAME"
+          echo "RPM_OUTPUT_FILE_NAME=$RPM_FILE_NAME" >> $GITHUB_ENV
+          echo "RPM_OUTPUT_FILE=$(realpath $RPM_FILE_NAME)" >> $GITHUB_ENV
+
       - name: Create Windows installer
         if: startsWith(matrix.os, 'windows')
         run: |
@@ -294,6 +306,21 @@ jobs:
         with:
           name: "${{ env.OUTPUT_FILE_NAME }}"
           path: "${{ env.OUTPUT_FILE }}"
+          overwrite: true
+          retention-days: 14
+
+      - name: Generate RPM artifact attestation
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "${{ env.RPM_OUTPUT_FILE }}"
+
+      - name: Upload RPM artifact
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ env.RPM_OUTPUT_FILE_NAME }}"
+          path: "${{ env.RPM_OUTPUT_FILE }}"
           overwrite: true
           retention-days: 14
 

--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,16 @@ runtime {
         if (currentOs.windows) {
             installerOptions += ['--win-per-user-install', '--win-dir-chooser', '--win-menu', '--win-shortcut']
         } else if (currentOs.linux) {
+            // jpackage defaults to the native package type of the build host
+            // (deb on Ubuntu). Pass -PinstallerType=rpm to build an RPM for
+            // Fedora/RHEL instead (requires rpmbuild on the build machine).
+            if (project.hasProperty('installerType')) {
+                installerType = project.property('installerType')
+            }
             installerOptions += ['--linux-package-name', 'fqlite', '--linux-shortcut']
+            if (project.findProperty('installerType') == 'rpm') {
+                installerOptions += ['--linux-rpm-license-type', 'ASL 2.0']
+            }
         } else if (currentOs.isMacOsX()) {
             imageOptions += ['--mac-package-name', 'fqlite']
             skipInstaller = true


### PR DESCRIPTION
## Summary

FQLite releases currently ship a `.deb` for Linux, but nothing installable on Fedora/RHEL-family systems. This PR adds an `.rpm` artifact to the release builds.

### Changes

- **build.gradle**: new optional Gradle property `-PinstallerType` that is forwarded to jpackage's `--type` on Linux (jpackage otherwise defaults to the native package type of the build host, i.e. deb on the Ubuntu runner). When building an RPM, the Apache-2.0 license tag (`--linux-rpm-license-type 'ASL 2.0'`) is set as well.
- **.github/workflows/build.yml** and **build_secure.yml**: after the existing deb step on the Ubuntu runner, install `rpm` (provides `rpmbuild`, which jpackage needs for `--type rpm`), rebuild with `-PinstallerType=rpm`, and attest + upload the resulting `fqlite-<version>-x86_64.rpm` alongside the other artifacts. The publish job picks it up automatically since it collects `artifacts/*`.

No change to the existing deb/dmg/exe outputs.

### Testing

Local verification wasn't possible (host has only JDK 25; Gradle 8.10.2 doesn't run on it), so the workflow run on this branch is the intended verification — happy to iterate if the RPM step needs adjustment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)